### PR TITLE
Avoid publishing test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
   "bugs": {
     "url": "https://github.com/tracker1/node-rsa-pem-from-mod-exp/issues"
   },
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
   "devDependencies": {
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",


### PR DESCRIPTION
This package showed up in a security scan due to the tokens in [signature.tests.js](https://github.com/tracker1/node-rsa-pem-from-mod-exp/blob/master/test/signature.tests.js). Ideally any test files are not published with the package to npm, which is what this PR aims to solve by setting the package.json files property ([docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files)).

**Before**
```shell
> npm pack --dry-run                  
npm notice 
npm notice 📦  rsa-pem-from-mod-exp@0.8.6
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE                
npm notice 1.6kB README.md              
npm notice 163B  index.d.ts             
npm notice 1.8kB index.js               
npm notice 684B  package.json           
npm notice 420B  test/index.tests.js    
npm notice 1.7kB test/input.json        
npm notice 5.2kB test/signature.tests.js
```

**After**
```shell
> npm pack --dry-run             
npm notice 
npm notice 📦  rsa-pem-from-mod-exp@0.8.6
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE     
npm notice 1.6kB README.md   
npm notice 163B  index.d.ts  
npm notice 1.8kB index.js    
npm notice 735B  package.json
```